### PR TITLE
Volume buttons used ingame if checkbox is checked

### DIFF
--- a/src/in/celest/LauncherActivity.java
+++ b/src/in/celest/LauncherActivity.java
@@ -232,7 +232,7 @@ public class LauncherActivity extends Activity {
             immersiveMode.setChecked(mPref.getBoolean("immersive_mode", true));
         }
         showtouch.setChecked(mPref.getBoolean("show_touch", true));
-        useVolumeButtons.setChecked(mPref.getBoolean("use_volume_buttons", true));
+        useVolumeButtons.setChecked(mPref.getBoolean("use_volume_buttons", false));
     }
 
     /* access modifiers changed from: package-private */

--- a/src/in/celest/LauncherActivity.java
+++ b/src/in/celest/LauncherActivity.java
@@ -43,6 +43,7 @@ public class LauncherActivity extends Activity {
     public static SharedPreferences mPref;
     public static final int sdk = Integer.valueOf(Build.VERSION.SDK).intValue();
     static CheckBox showtouch;
+    static CheckBox useVolumeButtons;
     static Spinner spin;
 
     public static native boolean checkCert(String cert);
@@ -179,6 +180,10 @@ public class LauncherActivity extends Activity {
         showtouch.setLayoutParams(buttonparams);
         showtouch.setText("Show Touch");
 
+        useVolumeButtons = new CheckBox(this);
+        useVolumeButtons.setLayoutParams(buttonparams);
+        useVolumeButtons.setText("Use volume buttons");
+
         Button button = (Button)findViewById(R.id.button_launch);
 
         button.setOnClickListener(new View.OnClickListener() {
@@ -213,6 +218,7 @@ public class LauncherActivity extends Activity {
         body.addView(textView4);
 	body.addView(spin);
         body.addView(showtouch);
+        body.addView(useVolumeButtons);
         if (sdk >= 19) {
             body.addView(immersiveMode);
         }
@@ -226,6 +232,7 @@ public class LauncherActivity extends Activity {
             immersiveMode.setChecked(mPref.getBoolean("immersive_mode", true));
         }
         showtouch.setChecked(mPref.getBoolean("show_touch", true));
+        useVolumeButtons.setChecked(mPref.getBoolean("use_volume_buttons", true));
     }
 
     /* access modifiers changed from: package-private */
@@ -349,6 +356,7 @@ public class LauncherActivity extends Activity {
                 editor.putBoolean("immersive_mode", false);
             }
             editor.putBoolean("show_touch", showtouch.isChecked());
+            editor.putBoolean("use_volume_buttons", useVolumeButtons.isChecked());
             editor.commit();
             Intent intent = new Intent(this, SDLActivity.class);
             intent.addFlags(268435456);

--- a/src/org/libsdl/app/SDLSurface.java
+++ b/src/org/libsdl/app/SDLSurface.java
@@ -20,12 +20,14 @@ import java.io.FileWriter;
 import java.io.IOException;
 import com.valvesoftware.ValveActivity2;
 
+import in.celest.LauncherActivity;
+
 public class SDLSurface
-extends SurfaceView
-implements SurfaceHolder.Callback,
-View.OnKeyListener,
-View.OnTouchListener,
-SensorEventListener {
+        extends SurfaceView
+        implements SurfaceHolder.Callback,
+        View.OnKeyListener,
+        View.OnTouchListener,
+        SensorEventListener {
     public static float mHeight;
     private static SensorManager mSensorManager;
     public static float mWidth;
@@ -77,11 +79,11 @@ SensorEventListener {
     }
 
     public boolean onKey(View view, int n, KeyEvent keyEvent) {
-       if( n == KeyEvent.KEYCODE_VOLUME_DOWN || n == KeyEvent.KEYCODE_VOLUME_UP )
+        if(( n == KeyEvent.KEYCODE_VOLUME_DOWN || n == KeyEvent.KEYCODE_VOLUME_UP) && !LauncherActivity.mPref.getBoolean( "use_volume_buttons", false ))
             return false;
 
-       if( n == KeyEvent.KEYCODE_BACK )
-			n = KeyEvent.KEYCODE_ESCAPE;
+        if( n == KeyEvent.KEYCODE_BACK )
+            n = KeyEvent.KEYCODE_ESCAPE;
         if (keyEvent.getAction() == 0) {
             SDLActivity.onNativeKeyDown(n);
             return true;
@@ -108,51 +110,51 @@ SensorEventListener {
         float x,y,p;
 
         switch(action) {
-		case MotionEvent.ACTION_MOVE:
-			for( i = 0; i < pointerCount; i++ )
-			{
-				pointerFingerId = event.getPointerId( i );
-				x = event.getX( i );
-				y = event.getY( i );
-				p = event.getPressure( i );
-				ValveActivity2.TouchEvent( pointerFingerId, x/mWidth, y/mHeight, 2 );
-			}
-			break;
+            case MotionEvent.ACTION_MOVE:
+                for( i = 0; i < pointerCount; i++ )
+                {
+                    pointerFingerId = event.getPointerId( i );
+                    x = event.getX( i );
+                    y = event.getY( i );
+                    p = event.getPressure( i );
+                    ValveActivity2.TouchEvent( pointerFingerId, x/mWidth, y/mHeight, 2 );
+                }
+                break;
 
-		case MotionEvent.ACTION_UP:
-		case MotionEvent.ACTION_DOWN:
-			i = 0;
-		case MotionEvent.ACTION_POINTER_UP:
-		case MotionEvent.ACTION_POINTER_DOWN:
-			// Non primary pointer up/down
-			if( i == -1 )
-			{
-				i = event.getActionIndex();
-			}
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_DOWN:
+                i = 0;
+            case MotionEvent.ACTION_POINTER_UP:
+            case MotionEvent.ACTION_POINTER_DOWN:
+                // Non primary pointer up/down
+                if( i == -1 )
+                {
+                    i = event.getActionIndex();
+                }
 
-			pointerFingerId = event.getPointerId( i );
+                pointerFingerId = event.getPointerId( i );
 
-			x = event.getX( i );
-			y = event.getY( i );
-			Log.v((String)"SDL", (String)"x: "+x);
-			Log.v((String)"SDL", (String)"y: "+y);
-				if( action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_POINTER_UP )
-					ValveActivity2.TouchEvent( pointerFingerId, x/mWidth, y/mHeight, 1 );
-				if( action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN )
-					ValveActivity2.TouchEvent( pointerFingerId, x/mWidth, y/mHeight, 0 );
-			break;
-		case MotionEvent.ACTION_CANCEL:
-			for( i = 0; i < pointerCount; i++ )
-			{
-				pointerFingerId = event.getPointerId( i );
-				x = event.getX( i );
-				y = event.getY( i );
-				ValveActivity2.TouchEvent( pointerFingerId, x/mWidth, y/mHeight, 1 );
-			}
-			break;
+                x = event.getX( i );
+                y = event.getY( i );
+                Log.v((String)"SDL", (String)"x: "+x);
+                Log.v((String)"SDL", (String)"y: "+y);
+                if( action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_POINTER_UP )
+                    ValveActivity2.TouchEvent( pointerFingerId, x/mWidth, y/mHeight, 1 );
+                if( action == MotionEvent.ACTION_DOWN || action == MotionEvent.ACTION_POINTER_DOWN )
+                    ValveActivity2.TouchEvent( pointerFingerId, x/mWidth, y/mHeight, 0 );
+                break;
+            case MotionEvent.ACTION_CANCEL:
+                for( i = 0; i < pointerCount; i++ )
+                {
+                    pointerFingerId = event.getPointerId( i );
+                    x = event.getX( i );
+                    y = event.getY( i );
+                    ValveActivity2.TouchEvent( pointerFingerId, x/mWidth, y/mHeight, 1 );
+                }
+                break;
 
-                        default: break;
-	}
+            default: break;
+        }
 
         return true;
     }
@@ -173,8 +175,8 @@ SensorEventListener {
 
                 @Override
                 public void run() {
-			if( SDLActivity.mImmersiveMode != null )
-                       		SDLActivity.mImmersiveMode.apply();
+                    if( SDLActivity.mImmersiveMode != null )
+                        SDLActivity.mImmersiveMode.apply();
                     /*SDLSurface.this.setSystemUiVisibility(5894);
                     if (SDLSurface.this.getSystemUiVisibility() != 5894) {
                         this.waitTime += 500;
@@ -199,7 +201,7 @@ SensorEventListener {
      */
     public void surfaceChanged(SurfaceHolder surfaceHolder, int n, int n2, int n3) {
         mWidth = n2;
-	mHeight = n3;
+        mHeight = n3;
         n2 = 353701890;
         switch (n) {
             default: {
@@ -262,8 +264,8 @@ SensorEventListener {
         Log.v((String)"SDL", (String)("Window size:" + mWidth + "x" + mHeight));
         SDLActivity.mIsSurfaceReady = true;
         SDLActivity.onNativeSurfaceChanged();
-	SDLActivity.startApp();
-}
+        SDLActivity.startApp();
+    }
 
     public void surfaceCreated(SurfaceHolder surfaceHolder) {
         surfaceHolder.setType(2);


### PR DESCRIPTION
Allows to use volume (up/down) ingame.

However it has to be binded in config, so it is also possible to map them as l2/r2 buttons (these are binded already):

public boolean onKey(View view, int n, KeyEvent keyEvent) {
        if(( n == KeyEvent.KEYCODE_VOLUME_DOWN || n == KeyEvent.KEYCODE_VOLUME_UP) && !LauncherActivity.mPref.getBoolean( "use_volume_buttons", false ))
            return false;
        if( n == KeyEvent.KEYCODE_VOLUME_DOWN){
            if (keyEvent.getAction() == 0) {
                SDLActivity.onNativeKeyDown(KeyEvent.KEYCODE_BUTTON_R2);
                return true;
            }
            if (keyEvent.getAction() == 1) {
                SDLActivity.onNativeKeyUp(KeyEvent.KEYCODE_BUTTON_L2);
                return true;
            }
        }
        if(n == KeyEvent.KEYCODE_VOLUME_UP){
            if (keyEvent.getAction() == 0) {
                SDLActivity.onNativeKeyDown(n);
                return true;
            }
            if (keyEvent.getAction() == 1) {
                SDLActivity.onNativeKeyUp(n);
                return true;
            }
        }

        if( n == KeyEvent.KEYCODE_BACK )
            n = KeyEvent.KEYCODE_ESCAPE;
        if (keyEvent.getAction() == 0) {
            SDLActivity.onNativeKeyDown(n);
            return true;
        }
        if (keyEvent.getAction() == 1) {
            SDLActivity.onNativeKeyUp(n);
            return true;
        }
        return false;
    }